### PR TITLE
Add snapshot to gnosis dapp catalog

### DIFF
--- a/src/catalogs/wallet-gnosis.applist.json
+++ b/src/catalogs/wallet-gnosis.applist.json
@@ -103,6 +103,28 @@
         "web",
         "mobile"
       ]
+    },
+    {
+      "id": "Snapshot",
+      "url": "https://snapshot.org/",
+      "name": "Snapshot",
+      "iconUrl": "https://snapshot.org/icon.svg",
+      "description": "Where decisions get made",
+      "networks": [
+        1,
+        10,
+        56,
+        100,
+        137,
+        250,
+        42161,
+        43114
+      ],
+      "forceInternal": true,
+      "applicationType": [
+        "web",
+        "mobile"
+      ]
     }
   ]
 }


### PR DESCRIPTION
add snapshot to dapp catalog as they added ambire to known hosts list it is now working